### PR TITLE
Redirect HTTP->HTTPS with $host variable

### DIFF
--- a/templates/vhost/_proxy.conf.erb
+++ b/templates/vhost/_proxy.conf.erb
@@ -4,7 +4,7 @@
   <% if @ssl_redirect -%>
         proxy_redirect http:// https://;
         if ($scheme = 'http') {
-          rewrite ^ https://$server_name$request_uri? permanent;
+          rewrite ^ https://$host$request_uri? permanent;
         }
   <% else -%>
         proxy_redirect             off;


### PR DESCRIPTION
Use `$host` instead of `$server_name` when redirecting from HTTP to HTTPS.
This means that the client will continue using the same hostname that they
came in on, rather than being redirected out to the canonical address, which
is the first value of the `server_name` directive. This is useful for server
aliases (additional args to `server_name`).
## 

To be used for CI.

/cc @samjsharpe @nickstenning @danielabel
