### PR TITLE
Make client_max_body_size a parameter on nginx::vhost::proxy

### DIFF
--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -44,6 +44,7 @@ define nginx::vhost::proxy (
   $isdefaultvhost      = false,
   $proxy               = true,
   $forward_host_header = true,
+  $client_max_body_size = '10m',
 ) {
 
   include nginx

--- a/templates/vhost/_proxy.conf.erb
+++ b/templates/vhost/_proxy.conf.erb
@@ -18,7 +18,7 @@
         proxy_set_header           Host  $host;
   <% end -%>
 
-        client_max_body_size       10m;
+        client_max_body_size       <%= @client_max_body_size %>;
         client_body_buffer_size    128k;
 
         proxy_connect_timeout      90;


### PR DESCRIPTION
This simply exposes the parameter so it can be configured via Hiera. This is required by us as the default 10MB isn't enough for running a Docker registry, where images can be over 50MB.
