### PR TITLE
Add set_host_header param to proxy vhost

### DIFF
--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -44,6 +44,7 @@ define nginx::vhost::proxy (
   $isdefaultvhost      = false,
   $proxy               = true,
   $forward_host_header = true,
+  $set_host_header     = undef,
 ) {
 
   include nginx
@@ -53,6 +54,10 @@ define nginx::vhost::proxy (
     $srvname = $name
   } else {
     $srvname = $servername
+  }
+
+  if ($set_host_header and $forward_host_header) {
+    fail("Cannot use both set_host_header and forward_host_header!")
   }
 
   file { "${nginx::params::vdir}/${priority}-${name}_proxy":

--- a/templates/vhost/_proxy.conf.erb
+++ b/templates/vhost/_proxy.conf.erb
@@ -17,6 +17,9 @@
   <% if @forward_host_header -%>
         proxy_set_header           Host  $host;
   <% end -%>
+  <% if @set_host_header -%>
+        proxy_set_header           Host  '<%= @set_host_header %>';
+  <% end -%>
 
         client_max_body_size       10m;
         client_body_buffer_size    128k;


### PR DESCRIPTION
Allow explicit setting of the Host header forwarded to the proxy backend.

This is a merge of Nick's work from origin/set-host-header.
