### PR TITLE
Allow server_tokens to be parameterised

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,10 @@ class nginx::params {
 
   $server_names_hash_bucket_size = 32
 
+  # allow people to disable server_tokens - by default we shouldn't
+  # leak this information
+  $server_tokens = "off"
+
   case $operatingsystem {
     'debian',
     'ubuntu': {

--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -21,7 +21,7 @@ http {
   tcp_nodelay on;
   keepalive_timeout 65;
   types_hash_max_size 2048;
-  # server_tokens off;
+  server_tokens <%= server_tokens %>;
 
   server_names_hash_bucket_size <%= server_names_hash_bucket_size %>;
   # server_name_in_redirect off;


### PR DESCRIPTION
As part of a recent ITHC / penetration test, we were advised not
to disclose this information in responses. Easy enough to fix.
