### PR TITLE
Add access and error log customisation

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -23,7 +23,9 @@ define nginx::vhost(
   $isdefaultvhost   = false,
   $vhostroot        = '',
   $autoindex        = false,
-  $webroot          = $nginx::server::default_webroot
+  $webroot          = $nginx::server::default_webroot,
+  $access_logs      = { '{name}.access.log' => '' },
+  $error_logs       = { '{name}.error.log' => '' },
 ) {
 
   include nginx

--- a/manifests/vhost/homedir.pp
+++ b/manifests/vhost/homedir.pp
@@ -22,6 +22,8 @@ define nginx::vhost::homedir (
   $isdefaultvhost = false,
   $homedir        = '/home',
   $pubdir         = 'public_html',
+  $access_logs    = { '{name}.access.log' => '' },
+  $error_logs     = { '{name}.error.log' => '' },
 ) {
 
   include nginx

--- a/manifests/vhost/redirect.pp
+++ b/manifests/vhost/redirect.pp
@@ -22,6 +22,8 @@ define nginx::vhost::redirect (
   $status         = 'permanent',
   $magic          = '',
   $isdefaultvhost = false,
+  $access_logs    = { '{name}.access.log' => '' },
+  $error_logs     = { '{name}.error.log' => '' },
 ) {
 
   include nginx


### PR DESCRIPTION
While you had been able customize location and format of logs for a
proxy vhost it was broken for all other types of vhost.
