### PR TITLE
Add flag to append proxy host to forwarded headers

### DIFF
--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -44,6 +44,7 @@ define nginx::vhost::proxy (
   $isdefaultvhost      = false,
   $proxy               = true,
   $proxy_magic         = '',
+  $proxy_append_forwarded_host = false,
   $forward_host_header = true,
   $client_max_body_size = '10m',
   $access_logs         = { '{name}.access.log' => '' },

--- a/templates/vhost/_proxy.conf.erb
+++ b/templates/vhost/_proxy.conf.erb
@@ -12,8 +12,13 @@
         proxy_set_header           X-Real-IP   $remote_addr;
         proxy_set_header           X-Forwarded-For  $proxy_add_x_forwarded_for;
         proxy_set_header           X-Forwarded-Proto  $scheme;
-        proxy_set_header           X-Forwarded-Server  $host;
+      <% if @proxy_append_forwarded_host -%>
+        proxy_set_header           X-Forwarded-Server  "$http_x_forwarded_server,$host";
+        proxy_set_header           X-Forwarded-Host  "$http_x_forwarded_host,$host";
+      <% else -%>
+        proxy_set_header           X-Forwarded-Server $host;
         proxy_set_header           X-Forwarded-Host  $host;
+      <% end -%>
   <% if @forward_host_header -%>
         proxy_set_header           Host  $host;
   <% end -%>


### PR DESCRIPTION
If there are multiple proxying steps the host name of this vhost may not
be the only forwarded host name. This flags allows the user to append
the host name onto an incomming X-Forwarded-{Server,Host} header rather
than setting it.

Ideally the HttpProxyModule would provide variables that handle this
(like `$proxy_add_x_forwarded_for`) but it doesn't.
