### PR TITLE
Add version parameter to freeze a version of nginx

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -7,6 +7,7 @@
 # Debian/ubuntu at present.
 #
 class nginx::server (
+  $version                       = present,
   $threadcount                   = $nginx::params::threadcount,
   $server_names_hash_bucket_size = $nginx::params::server_names_hash_bucket_size,
   $default_ssl_path              = $nginx::params::default_ssl_path,
@@ -28,7 +29,7 @@ class nginx::server (
   }
 
   package{ 'nginx':
-    ensure => present,
+    ensure => $version,
     name   => $nginx::params::package,
   }
 


### PR DESCRIPTION
We don't always want to just ensure that the package nginx is installed,
sometimes we will want a particular version. We should add the ability
for us to change the version used by nginx::server
