### PR TITLE
Fix warnings

### DIFF
--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -1,8 +1,8 @@
 # Mostly stock, managed by Puppet, beware.
 #
 
-user <%= user %>;
-worker_processes <%= threadcount %>;
+user <%= @user %>;
+worker_processes <%= @threadcount %>;
 pid /var/run/nginx.pid;
 
 events {
@@ -21,12 +21,12 @@ http {
   tcp_nodelay on;
   keepalive_timeout 65;
   types_hash_max_size 2048;
-  server_tokens <%= server_tokens %>;
+  server_tokens <%= @server_tokens %>;
 
-  server_names_hash_bucket_size <%= server_names_hash_bucket_size %>;
+  server_names_hash_bucket_size <%= @server_names_hash_bucket_size %>;
   # server_name_in_redirect off;
 
-  include <%= etcdir %>/mime.types;
+  include <%= @etcdir %>/mime.types;
   default_type application/octet-stream;
 
   ##
@@ -71,8 +71,8 @@ http {
   # Virtual Host Configs
   ##
 
-  include <%= etcdir %>/conf.d/*.conf;
-  include <%= etcdir %>/sites-enabled/*;
+  include <%= @etcdir %>/conf.d/*.conf;
+  include <%= @etcdir %>/sites-enabled/*;
 }
 
 

--- a/templates/vhost-proxy.conf.erb
+++ b/templates/vhost-proxy.conf.erb
@@ -15,5 +15,5 @@ server {
 <%= scope.function_template(['nginx/vhost/_proxy.conf.erb']) %>
 
     # Any other spurious options can go here via the medium of magic
-    <%= magic %>
+    <%= @magic %>
 }

--- a/templates/vhost/_listen.conf.erb
+++ b/templates/vhost/_listen.conf.erb
@@ -1,21 +1,21 @@
 <%# Configuration fragment for listening on IPv4 and IPv6 with SSL %>
 <% unless @sslonly -%>
-  listen   <%= port %><%= " default" if @isdefaultvhost %>;
+  listen   <%= @port %><%= " default" if @isdefaultvhost %>;
 <%   if scope.lookupvar('::ipaddress6') -%>
   # Listen on an ipv6 version of this port too, but only do v6 on it, so we
   # don't get strange v4 mapped IPs in v6. Only enable this if this is the
   # default vhost; if 'ipv6only=on' is declared twice then the nginx syntax
   # check will throw this:
   # [emerg] duplicate listen options for [::]:80 in /etc/nginx/sites-enabled/vhost
-  listen   [::]:<%= port %><%= " default ipv6only=on" if @isdefaultvhost %>;
+  listen   [::]:<%= @port %><%= " default ipv6only=on" if @isdefaultvhost %>;
 <%   end -%>
 <% end -%>
 
-<% if ssl -%>
-  listen   <%= ssl_port %><%= " default" if @isdefaultvhost %> ssl;
+<% if @ssl -%>
+  listen   <%= @ssl_port %><%= " default" if @isdefaultvhost %> ssl;
 <%   if scope.lookupvar('::ipaddress6') -%>
   # See the above rambling about ipv6only on default vhosts
-  listen   [::]:<%= ssl_port %><%= " default ipv6only=on" if @isdefaultvhost %> ssl;
+  listen   [::]:<%= @ssl_port %><%= " default ipv6only=on" if @isdefaultvhost %> ssl;
 <%   end -%>
 
   ssl_certificate      <%= ssl_path %>/<%= ssl_cert %>;
@@ -24,7 +24,7 @@
   ssl_prefer_server_ciphers on;
   ssl_session_timeout  10m;
   ssl_protocols        TLSv1.2 TLSv1.1 TLSv1 SSLv3;
-  ssl_session_cache    shared:SSL_<%= name %>:1m;
+  ssl_session_cache    shared:SSL_<%= @name %>:1m;
 
   # Redirect non-SSL on SSL port to SSL..
   # http://www.ruby-forum.com/topic/193781#844520

--- a/templates/vhost/_servername.conf.erb
+++ b/templates/vhost/_servername.conf.erb
@@ -1,11 +1,11 @@
 <% if @serveraliases -%>
   <% if @serveraliases.is_a? String -%>
-  server_name <%= srvname %> <%= @serveraliases %>;
+  server_name <%= @srvname %> <%= @serveraliases %>;
   <% elsif @serveraliases.is_a? Array -%>
-  server_name <%= srvname %> <%= @serveraliases.join(' ') %>;
+  server_name <%= @srvname %> <%= @serveraliases.join(' ') %>;
   <% else -%>
     <% raise ArgumentError, "Expected @serveraliases to be one of [String, Array], got '#{@serveraliases.inspect}:#{@serveraliases.class}'" -%>
   <% end -%>
 <% else -%>
-  server_name <%= srvname %>;
+  server_name <%= @srvname %>;
 <% end -%>


### PR DESCRIPTION
For example:

```
Warning: Variable access via 'magic' is deprecated. Use '@magic' instead.
template[/var/apps/pp-puppet/vendor/modules/nginx/templates/vhost-proxy.conf.erb]:18
```
