### PR TITLE
Allow the X-Forwarded-* to be set to single host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pkg
 .rspec_system/
 spec/fixtures
 Gemfile.lock
+.bundle

--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -45,6 +45,7 @@ define nginx::vhost::proxy (
   $proxy               = true,
   $proxy_magic         = '',
   $proxy_append_forwarded_host = false,
+  $proxy_set_forwarded_host = false,
   $forward_host_header = true,
   $client_max_body_size = '10m',
   $access_logs         = { '{name}.access.log' => '' },
@@ -58,6 +59,10 @@ define nginx::vhost::proxy (
     $srvname = $name
   } else {
     $srvname = $servername
+  }
+
+  if $proxy_append_forwarded_host and $proxy_set_forwarded_host {
+    fail('Forwarded host cannot be both set and appended to')
   }
 
   file { "${nginx::params::vdir}/${priority}-${name}_proxy":

--- a/templates/vhost/_proxy.conf.erb
+++ b/templates/vhost/_proxy.conf.erb
@@ -15,6 +15,11 @@
       <% if @proxy_append_forwarded_host -%>
         proxy_set_header           X-Forwarded-Server  "$http_x_forwarded_server,$host";
         proxy_set_header           X-Forwarded-Host  "$http_x_forwarded_host,$host";
+      <% elsif @proxy_set_forwarded_host -%>
+        # Some app servers (Django) don't support lists of forwarded hosts so
+        # if we want to proxy the X-Forwarded-Host we need to set it.
+        proxy_set_header           X-Forwarded-Server  "$http_x_forwarded_server";
+        proxy_set_header           X-Forwarded-Host  "$http_x_forwarded_host";
       <% else -%>
         proxy_set_header           X-Forwarded-Server $host;
         proxy_set_header           X-Forwarded-Host  $host;


### PR DESCRIPTION
Some app server (Django) do not support lists for X-Forwarded-Server or
X-Forwarded-Host. This change allows those headers to be proxied on
their own.

On Django specifically; they have stated that they will not fix.
https://code.djangoproject.com/ticket/9064
