### PR TITLE
Fix more deprecation warnings

### DIFF
--- a/templates/vhost-default.conf.erb
+++ b/templates/vhost-default.conf.erb
@@ -11,11 +11,11 @@ server {
   <%= scope.function_template(['nginx/vhost/_logging.conf.erb']) %>
 
   location / {
-    root <%= docroot %>;
+    root <%= @docroot %>;
     <%= scope.function_template(['nginx/vhost/_index.conf.erb']) %>
   }
 
   # Anything here is added by use of "magic" so is pretty jazzy.
-  <%= magic %>
+  <%= @magic %>
 }
 

--- a/templates/vhost/_index.conf.erb
+++ b/templates/vhost/_index.conf.erb
@@ -1,6 +1,6 @@
 <%# Configuration fragment for the configuration of default indexing %>
 
-<% if autoindex -%>
+<% if @autoindex -%>
     autoindex on;
 <% else -%>
     index  index.html index.htm;

--- a/templates/vhost/_listen.conf.erb
+++ b/templates/vhost/_listen.conf.erb
@@ -18,8 +18,8 @@
   listen   [::]:<%= @ssl_port %><%= " default ipv6only=on" if @isdefaultvhost %> ssl;
 <%   end -%>
 
-  ssl_certificate      <%= ssl_path %>/<%= ssl_cert %>;
-  ssl_certificate_key  <%= ssl_path %>/<%= ssl_key %>;
+  ssl_certificate      <%= @ssl_path %>/<%= @ssl_cert %>;
+  ssl_certificate_key  <%= @ssl_path %>/<%= @ssl_key %>;
   ssl_ciphers          RC4:HIGH:!aNULL:!MD5;  # use decent and non-crap ciphers.
   ssl_prefer_server_ciphers on;
   ssl_session_timeout  10m;


### PR DESCRIPTION
 For example:

```
 Warning: Variable access via 'magic' is deprecated. Use '@magic' instead. template[/var/apps/pp-puppet/vendor/modules/nginx/templates/vhost-default.conf.erb]:14
```
