### PR TITLE
Add a parameter to vhost::proxy to deny by verb

### DIFF
--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -50,6 +50,7 @@ define nginx::vhost::proxy (
   $client_max_body_size = '10m',
   $access_logs         = { '{name}.access.log' => '' },
   $error_logs          = { '{name}.error.log' => '' },
+  $denied_http_verbs   = [],
 ) {
 
   include nginx
@@ -64,6 +65,8 @@ define nginx::vhost::proxy (
   if $proxy_append_forwarded_host and $proxy_set_forwarded_host {
     fail('Forwarded host cannot be both set and appended to')
   }
+
+  validate_array($denied_http_verbs)
 
   file { "${nginx::params::vdir}/${priority}-${name}_proxy":
     content => template($template),

--- a/templates/vhost/_proxy.conf.erb
+++ b/templates/vhost/_proxy.conf.erb
@@ -40,6 +40,8 @@
         proxy_busy_buffers_size    64k;
         proxy_temp_file_write_size 64k;
   <% if @denied_http_verbs and @denied_http_verbs.length > 0 -%>
+        # Join denied verbs together into an alternation statement
+        # ['PURGE', 'DELETE'] -> '^(?:PURGE|DELETE)$'
         if ( $request_method ~ '^(?:<%= @denied_http_verbs.join('|') -%>)$' ) {
           return 403;
         }

--- a/templates/vhost/_proxy.conf.erb
+++ b/templates/vhost/_proxy.conf.erb
@@ -39,9 +39,13 @@
         proxy_buffers              4 32k;
         proxy_busy_buffers_size    64k;
         proxy_temp_file_write_size 64k;
-
- <% if @proxy_magic -%>
+  <% if @denied_http_verbs and @denied_http_verbs.length > 0 -%>
+        if ( $request_method ~ '^(?:<%= @denied_http_verbs.join('|') -%>)$' ) {
+          return 403;
+        }
+  <% end -%>
+  <% if @proxy_magic -%>
        <%= @proxy_magic -%>
-<% end -%>
+  <% end -%>
     }
 <% end -%>


### PR DESCRIPTION
Add the $denied_http_verbs argument to the nginx::vhost::proxy defined
type to allow HTTP verbs to be denied. It accepts an array of verbs to
block. It causes Nginx to return a 403.
