### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![Build Status](https://travis-ci.org/alphagov/puppet-nginx.png?branch=master)](https://travis-ci.org/alphagov/puppet-nginx)
 
+# DEPRECATED
+
+This fork is no longer maintained. You may wish to use [puppetlabs-operations/puppet-nginx](https://github.com/puppetlabs-operations/puppet-nginx) instead.
+
 # Puppet-nginx
 
 A puppet module to manage the nginx webserver.


### PR DESCRIPTION
I don't know of any team in GDS that uses this fork, so we should deprecate it.

I would expect that any useful changes/features/bugfixes will have already been submitted upstream.
